### PR TITLE
Update ElmahSensitiveDataFilterEventHandler.cs

### DIFF
--- a/ElmahSensitiveDataFiltering/ElmahSensitiveDataFilterEventHandler.cs
+++ b/ElmahSensitiveDataFiltering/ElmahSensitiveDataFilterEventHandler.cs
@@ -37,11 +37,15 @@ namespace ElmahSensitiveDataFiltering
             {
                 lock (_locker)
                 {
-                    var errorModule = GetErrorLogModule(HttpContext.Current.ApplicationInstance);
-                    if (errorModule != null)
+                    //check if the event was attached while we were waiting for the lock
+                    if (!_eventAttached)
                     {
-                        errorModule.Filtering += FilterException;
-                        _eventAttached = true;
+                        var errorModule = GetErrorLogModule(HttpContext.Current.ApplicationInstance);
+                        if (errorModule != null)
+                        {
+                            errorModule.Filtering += FilterException;
+                            _eventAttached = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Bug fix: Added a double check lock pattern (https://en.wikipedia.org/wiki/Double-checked_locking).

Once you've acquired the lock, you need to check again whether the event has been attached.  The first person through will attach the event, while all other requests will be waiting to acquire the lock.  All of those subsequent requests also need to check if the event has been attached, otherwise they will also attach the event (and you'll end up with multiple event subscribers).

The way the file currently is, with the if-statement first and the lock-statement second, means that if you get 5 people hit it at the same time, the first person will acquire the lock and attach the event, then the second person will acquire the lock and then attach the event, and then the third and so on (i.e. it will get attached 5 times).  That's why you need another if-statement once you've acquired the lock.
